### PR TITLE
fix: pass correct menu item index in WM_INITMENUPOPUP lParam for submenus

### DIFF
--- a/src/shell/contextmenu/contextmenu.cc
+++ b/src/shell/contextmenu/contextmenu.cc
@@ -135,7 +135,8 @@ std::vector<std::string> extract_hotkeys(const std::string &name) {
 
 menu menu::construct_with_hmenu(
     HMENU hMenu, HWND hWnd, bool is_top,
-    std::function<void(int, WPARAM, LPARAM)> HandleMenuMsg) {
+    std::function<void(int, WPARAM, LPARAM)> HandleMenuMsg,
+    LPARAM init_popup_lparam) {
     menu m;
 
     if (!HandleMenuMsg)
@@ -144,7 +145,7 @@ menu menu::construct_with_hmenu(
         };
 
     HandleMenuMsg(WM_INITMENUPOPUP, reinterpret_cast<WPARAM>(hMenu),
-                  0xFFFFFFFF);
+                  init_popup_lparam);
     for (int i = 0; i < GetMenuItemCount(hMenu); i++) {
         menu_item item;
         wchar_t buffer[256];
@@ -180,11 +181,9 @@ menu menu::construct_with_hmenu(
             int submenu_pos = i;
             item.submenu = [=](std::shared_ptr<menu_widget> mw) {
                 auto task = [&]() {
-                    HandleMenuMsg(WM_INITMENUPOPUP,
-                                  reinterpret_cast<WPARAM>(info.hSubMenu),
-                                  static_cast<LPARAM>(submenu_pos));
                     mw->init_from_data(menu::construct_with_hmenu(
-                        info.hSubMenu, hWnd, false, HandleMenuMsg));
+                        info.hSubMenu, hWnd, false, HandleMenuMsg,
+                        MAKELPARAM(static_cast<WORD>(submenu_pos), 0)));
                 };
                 if (main_thread_id == GetCurrentThreadId())
                     task();

--- a/src/shell/contextmenu/contextmenu.cc
+++ b/src/shell/contextmenu/contextmenu.cc
@@ -177,11 +177,12 @@ menu menu::construct_with_hmenu(
 
         if (info.hSubMenu) {
             auto main_thread_id = GetCurrentThreadId();
+            int submenu_pos = i;
             item.submenu = [=](std::shared_ptr<menu_widget> mw) {
                 auto task = [&]() {
                     HandleMenuMsg(WM_INITMENUPOPUP,
                                   reinterpret_cast<WPARAM>(info.hSubMenu),
-                                  0xFFFFFFFF);
+                                  static_cast<LPARAM>(submenu_pos));
                     mw->init_from_data(menu::construct_with_hmenu(
                         info.hSubMenu, hWnd, false, HandleMenuMsg));
                 };

--- a/src/shell/contextmenu/contextmenu.h
+++ b/src/shell/contextmenu/contextmenu.h
@@ -20,11 +20,9 @@ struct menu {
 
     static menu
     construct_with_hmenu(HMENU hMenu, HWND hWnd, bool is_top = true,
-                         // This is for handling submenus; messages are required
-                         // to be forwarded to IContextMenu2::HandleMenuMsg for
-                         // submenus and owner-draw menus to work properly
                          std::function<void(int, WPARAM, LPARAM)>
-                             HandleMenuMsg = {});
+                             HandleMenuMsg = {},
+                         LPARAM init_popup_lparam = 0xFFFFFFFF);
 };
 
 std::optional<int>


### PR DESCRIPTION
…enus

Previously, WM_INITMENUPOPUP was sent with lParam=0xFFFFFFFF for all submenus, which tells the context menu handler that the menu position is unknown. This caused the SendTo shell extension to fail to properly identify the submenu, resulting in it enumerating the wrong directory (user home directory instead of the SendTo folder).

Now we pass the actual menu item index as the low-order word of lParam, allowing context menu handlers to correctly identify which submenu is being initialized.