### PR TITLE
fix: prevent freeze on double right-click in directory background

### DIFF
--- a/src/shell/contextmenu/hooks.cc
+++ b/src/shell/contextmenu/hooks.cc
@@ -15,6 +15,7 @@
 #include "blook/blook.h"
 #include <atlcomcli.h>
 #include <atomic>
+#include <condition_variable>
 #include <mutex>
 #include <memory>
 #include <shobjidl_core.h>
@@ -376,21 +377,34 @@ std::optional<int>
 mb_shell::track_popup_menu(mb_shell::menu menu, int x, int y,
                            std::function<void(menu_render &)> on_before_show,
                            bool run_js) {
-    {
-        if (is_menu_showing.load(std::memory_order_relaxed)) {
-            spdlog::info("Re-entrant track_popup_menu detected, closing current menu first");
-            auto current = menu_render::current;
-            if (current && *current && (*current)->rt) {
-                (*current)->rt->hide_as_close();
+    struct menu_showing_guard {
+        bool owns = false;
+        ~menu_showing_guard() {
+            if (owns) {
+                is_menu_showing.store(false, std::memory_order_relaxed);
+                menu_close_cv.notify_all();
             }
-            std::unique_lock lock(menu_close_mutex);
-            menu_close_cv.wait_for(lock, std::chrono::milliseconds(2000), [] {
-                return !is_menu_showing.load(std::memory_order_relaxed);
-            });
-            if (is_menu_showing.load(std::memory_order_relaxed)) {
-                spdlog::warn("Previous menu did not close in time, aborting new menu");
-                return std::nullopt;
-            }
+        }
+    } showing_guard;
+
+    showing_guard.owns =
+        !is_menu_showing.exchange(true, std::memory_order_relaxed);
+    if (!showing_guard.owns) {
+        spdlog::info("Re-entrant track_popup_menu detected, closing current menu first");
+        auto current = menu_render::current;
+        if (current && *current && (*current)->rt) {
+            (*current)->rt->hide_as_close();
+        }
+        std::unique_lock lock(menu_close_mutex);
+        menu_close_cv.wait_for(lock, std::chrono::milliseconds(2000), [] {
+            return !is_menu_showing.load(std::memory_order_relaxed);
+        });
+        bool expected = false;
+        showing_guard.owns = is_menu_showing.compare_exchange_strong(
+            expected, true, std::memory_order_relaxed);
+        if (!showing_guard.owns) {
+            spdlog::warn("Previous menu did not close in time, aborting new menu");
+            return std::nullopt;
         }
     }
 
@@ -403,14 +417,11 @@ mb_shell::track_popup_menu(mb_shell::menu menu, int x, int y,
                     current_live_menu_handle.store(hMenu,
                                                    std::memory_order_relaxed);
                     mb_shell::context_menu_hooks::clear_active_root_menu_widget();
-                    is_menu_showing.store(true, std::memory_order_relaxed);
                 }
                 ~live_menu_guard() {
                     mb_shell::context_menu_hooks::clear_active_root_menu_widget();
                     current_live_menu_handle.store(nullptr,
                                                    std::memory_order_relaxed);
-                    is_menu_showing.store(false, std::memory_order_relaxed);
-                    menu_close_cv.notify_all();
                 }
             } guard((HMENU)menu.native_handle);
 

--- a/src/shell/contextmenu/hooks.cc
+++ b/src/shell/contextmenu/hooks.cc
@@ -32,6 +32,10 @@ std::atomic<void *> current_live_menu_handle = nullptr;
 std::mutex active_root_menu_mutex;
 std::weak_ptr<mb_shell::menu_widget> active_root_menu;
 
+static std::atomic<bool> is_menu_showing{false};
+static std::mutex menu_close_mutex;
+static std::condition_variable menu_close_cv;
+
 void *current_live_menu() {
     return current_live_menu_handle.load(std::memory_order_relaxed);
 }
@@ -372,6 +376,24 @@ std::optional<int>
 mb_shell::track_popup_menu(mb_shell::menu menu, int x, int y,
                            std::function<void(menu_render &)> on_before_show,
                            bool run_js) {
+    {
+        if (is_menu_showing.load(std::memory_order_relaxed)) {
+            spdlog::info("Re-entrant track_popup_menu detected, closing current menu first");
+            auto current = menu_render::current;
+            if (current && *current && (*current)->rt) {
+                (*current)->rt->hide_as_close();
+            }
+            std::unique_lock lock(menu_close_mutex);
+            menu_close_cv.wait_for(lock, std::chrono::milliseconds(2000), [] {
+                return !is_menu_showing.load(std::memory_order_relaxed);
+            });
+            if (is_menu_showing.load(std::memory_order_relaxed)) {
+                spdlog::warn("Previous menu did not close in time, aborting new menu");
+                return std::nullopt;
+            }
+        }
+    }
+
     auto thread_id_orig = GetCurrentThreadId();
     auto selected_menu_future = renderer_thread.add_task([&]() {
         set_thread_name("breeze::renderer_thread");
@@ -381,11 +403,14 @@ mb_shell::track_popup_menu(mb_shell::menu menu, int x, int y,
                     current_live_menu_handle.store(hMenu,
                                                    std::memory_order_relaxed);
                     mb_shell::context_menu_hooks::clear_active_root_menu_widget();
+                    is_menu_showing.store(true, std::memory_order_relaxed);
                 }
                 ~live_menu_guard() {
                     mb_shell::context_menu_hooks::clear_active_root_menu_widget();
                     current_live_menu_handle.store(nullptr,
                                                    std::memory_order_relaxed);
+                    is_menu_showing.store(false, std::memory_order_relaxed);
+                    menu_close_cv.notify_all();
                 }
             } guard((HMENU)menu.native_handle);
 

--- a/src/shell/contextmenu/menu_render.cc
+++ b/src/shell/contextmenu/menu_render.cc
@@ -113,11 +113,13 @@ menu_render menu_render::create(int x, int y, menu menu, bool run_js) {
     if (run_js) {
         spdlog::info("[perf] JS plugins start");
         auto before_js = rt->clock.now();
+        decltype(menu_callbacks_js) menu_callbacks_js_snapshot;
         {
             std::shared_lock lock(menu_callbacks_js_mutex);
-            for (auto &listener : menu_callbacks_js) {
-                listener->operator()(menu_info);
-            }
+            menu_callbacks_js_snapshot = menu_callbacks_js;
+        }
+        for (auto &listener : menu_callbacks_js_snapshot) {
+            listener->operator()(menu_info);
         }
         spdlog::info("[perf] JS plugins costed {}ms",
                std::chrono::duration_cast<std::chrono::milliseconds>(

--- a/src/shell/contextmenu/menu_render.cc
+++ b/src/shell/contextmenu/menu_render.cc
@@ -11,6 +11,7 @@
 #include "shell/logger.h"
 #include "shell/script/binding_types.hpp"
 #include <mutex>
+#include <shared_mutex>
 #include <thread>
 
 namespace mb_shell {
@@ -112,8 +113,11 @@ menu_render menu_render::create(int x, int y, menu menu, bool run_js) {
     if (run_js) {
         spdlog::info("[perf] JS plugins start");
         auto before_js = rt->clock.now();
-        for (auto &listener : menu_callbacks_js) {
-            listener->operator()(menu_info);
+        {
+            std::shared_lock lock(menu_callbacks_js_mutex);
+            for (auto &listener : menu_callbacks_js) {
+                listener->operator()(menu_info);
+            }
         }
         spdlog::info("[perf] JS plugins costed {}ms",
                std::chrono::duration_cast<std::chrono::milliseconds>(

--- a/src/shell/script/binding_types.cc
+++ b/src/shell/script/binding_types.cc
@@ -45,6 +45,7 @@ using namespace WinToastLib;
 std::vector<
     std::shared_ptr<std::function<void(mb_shell::js::menu_info_basic_js)>>>
     mb_shell::menu_callbacks_js;
+std::shared_mutex mb_shell::menu_callbacks_js_mutex;
 namespace mb_shell::js {
 bool menu_controller::valid() { return !$menu.expired(); }
 std::shared_ptr<mb_shell::js::menu_item_controller>
@@ -89,8 +90,14 @@ std::function<void()> menu_controller::add_menu_listener(
     };
     auto ptr =
         std::make_shared<std::function<void(menu_info_basic_js)>>(listener_cvt);
-    menu_callbacks_js.push_back(ptr);
-    return [ptr]() { std::erase(menu_callbacks_js, ptr); };
+    {
+        std::unique_lock lock(mb_shell::menu_callbacks_js_mutex);
+        menu_callbacks_js.push_back(ptr);
+    }
+    return [ptr]() {
+        std::unique_lock lock(mb_shell::menu_callbacks_js_mutex);
+        std::erase(menu_callbacks_js, ptr);
+    };
 }
 menu_controller::~menu_controller() {}
 int menu_item_controller::get_position() const {

--- a/src/shell/script/binding_types.hpp
+++ b/src/shell/script/binding_types.hpp
@@ -3,6 +3,7 @@
 #include <future>
 #include <memory>
 #include <optional>
+#include <shared_mutex>
 #include <stdlib.h>
 #include <string>
 #include <tuple>
@@ -718,4 +719,5 @@ namespace mb_shell {
 extern std::vector<
     std::shared_ptr<std::function<void(js::menu_info_basic_js)>>>
     menu_callbacks_js;
+extern std::shared_mutex menu_callbacks_js_mutex;
 } // namespace mb_shell

--- a/src/shell/script/script.cc
+++ b/src/shell/script/script.cc
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <ranges>
+#include <shared_mutex>
 #include <thread>
 
 #include "FileWatch.hpp"
@@ -45,11 +46,16 @@ script_context::script_context() {
 void script_context::watch_folder(const std::filesystem::path &path,
                                   std::function<bool()> on_reload) {
     bool has_update = false;
+    std::chrono::steady_clock::time_point last_change_time{};
+    static constexpr auto debounce_delay = std::chrono::milliseconds(500);
 
     auto reload_all = [&]() {
         spdlog::info("Reloading all scripts");
 
-        menu_callbacks_js.clear();
+        {
+            std::unique_lock lock(menu_callbacks_js_mutex);
+            menu_callbacks_js.clear();
+        }
         is_js_ready.store(false);
         module_base = path;
         stop_event_loop_in_time(std::chrono::milliseconds(500));
@@ -108,13 +114,17 @@ void script_context::watch_folder(const std::filesystem::path &path,
 
             spdlog::info("File change detected: {}", changed_path);
             has_update = true;
+            last_change_time = std::chrono::steady_clock::now();
         });
 
     while (true) {
         std::this_thread::sleep_for(std::chrono::milliseconds(300));
         if (has_update && on_reload()) {
-            has_update = false;
-            reload_all();
+            auto now = std::chrono::steady_clock::now();
+            if (now - last_change_time >= debounce_delay) {
+                has_update = false;
+                reload_all();
+            }
         }
     }
 }

--- a/src/shell/script/script.cc
+++ b/src/shell/script/script.cc
@@ -6,6 +6,7 @@
 #include "shell/logger.h"
 
 #include <algorithm>
+#include <mutex>
 #include <ranges>
 #include <shared_mutex>
 #include <thread>
@@ -45,6 +46,7 @@ script_context::script_context() {
 
 void script_context::watch_folder(const std::filesystem::path &path,
                                   std::function<bool()> on_reload) {
+    std::mutex file_change_mutex;
     bool has_update = false;
     std::chrono::steady_clock::time_point last_change_time{};
     static constexpr auto debounce_delay = std::chrono::milliseconds(500);
@@ -113,18 +115,28 @@ void script_context::watch_folder(const std::filesystem::path &path,
             }
 
             spdlog::info("File change detected: {}", changed_path);
-            has_update = true;
-            last_change_time = std::chrono::steady_clock::now();
+            {
+                std::lock_guard lock(file_change_mutex);
+                has_update = true;
+                last_change_time = std::chrono::steady_clock::now();
+            }
         });
 
     while (true) {
         std::this_thread::sleep_for(std::chrono::milliseconds(300));
-        if (has_update && on_reload()) {
-            auto now = std::chrono::steady_clock::now();
-            if (now - last_change_time >= debounce_delay) {
-                has_update = false;
-                reload_all();
+        bool should_reload = false;
+        {
+            std::lock_guard lock(file_change_mutex);
+            if (has_update && on_reload()) {
+                auto now = std::chrono::steady_clock::now();
+                if (now - last_change_time >= debounce_delay) {
+                    has_update = false;
+                    should_reload = true;
+                }
             }
+        }
+        if (should_reload) {
+            reload_all();
         }
     }
 }


### PR DESCRIPTION
## Problem

When performing two consecutive right-clicks on the directory background area, the file explorer freezes.

## Root Cause

Three interacting issues identified through debug.log analysis:

1. **Single-threaded renderer_thread deadlock**: The second track_popup_menu call gets queued behind the first one's event loop, causing the main thread to hang in nested wait_with_msgloop().
2. **Race condition on menu_callbacks_js**: The file watcher thread clears and repopulates menu_callbacks_js without synchronization, while the renderer thread iterates over it concurrently.
3. **Excessive script reloading**: Multiple file changes trigger cascading reloads without debouncing, causing init_known_strings to block for 200-700ms each time.

## Fixes

- Add re-entrancy protection to track_popup_menu: when a menu is already showing, close it first and wait for completion before creating a new one.
- Add std::shared_mutex for menu_callbacks_js: write lock for clear/add/remove operations, read lock for iteration.
- Add 500ms debounce delay for script reloading to batch file changes.

## Changed Files

- src/shell/contextmenu/hooks.cc - re-entrancy protection
- src/shell/contextmenu/menu_render.cc - shared_lock read protection
- src/shell/script/binding_types.hpp - declare menu_callbacks_js_mutex
- src/shell/script/binding_types.cc - define mutex, add write lock
- src/shell/script/script.cc - write lock protection and debounce