### PR TITLE
fix: context menu click not registering in third-party explorers

### DIFF
--- a/src/shell/contextmenu/menu_render.cc
+++ b/src/shell/contextmenu/menu_render.cc
@@ -87,7 +87,9 @@ menu_render menu_render::create(int x, int y, menu menu, bool run_js) {
     glfwMakeContextCurrent(rt->window);
     glfwSwapInterval(config::current->context_menu.vsync ? 1 : 0);
 
+    glfwSetWindowAttrib(rt->window, GLFW_MOUSE_PASSTHROUGH, GLFW_FALSE);
     rt->show();
+    SetCapture((HWND)rt->hwnd());
     auto menu_wid = std::make_shared<mouse_menu_widget_main>(
         menu,
         // convert the x and y to the window coordinates

--- a/src/shell/contextmenu/menu_widget.cc
+++ b/src/shell/contextmenu/menu_widget.cc
@@ -730,6 +730,19 @@ void mb_shell::mouse_menu_widget_main::update(ui::update_context &ctx) {
         calibrate_position(ctx);
         position_calibrated = true;
     }
+
+    // Override mouse state with GetAsyncKeyState for reliable detection
+    // in WS_EX_NOACTIVATE windows where GLFW may miss mouse messages
+    bool lmb_down = (GetAsyncKeyState(VK_LBUTTON) & 0x8000) != 0;
+    bool rmb_down = (GetAsyncKeyState(VK_RBUTTON) & 0x8000) != 0;
+    ctx.mouse_down = lmb_down;
+    ctx.right_mouse_down = rmb_down;
+    ctx.mouse_clicked = lmb_down && !prev_lmb_down;
+    ctx.right_mouse_clicked = rmb_down && !prev_rmb_down;
+    ctx.mouse_up = !lmb_down && prev_lmb_down;
+    prev_lmb_down = lmb_down;
+    prev_rmb_down = rmb_down;
+
     menu_wid->update(ctx);
 
     auto using_touchscreen = !IsCursorVisible();

--- a/src/shell/contextmenu/menu_widget.h
+++ b/src/shell/contextmenu/menu_widget.h
@@ -157,6 +157,8 @@ struct mouse_menu_widget_main : public ui::widget {
     mouse_menu_widget_main(menu menu_data, float x, float y);
     bool position_calibrated = false, direction_calibrated = false;
     bool ignore_outside_click_until_mouse_release = false;
+    bool prev_lmb_down = false;
+    bool prev_rmb_down = false;
     popup_direction direction;
     std::shared_ptr<menu_widget> menu_wid;
 


### PR DESCRIPTION
## Summary

- Use `GetAsyncKeyState` for mouse state detection instead of GLFW's `glfwGetMouseButton`, which may miss `WM_LBUTTONDOWN` messages in `WS_EX_NOACTIVATE` windows due to cross-thread message dispatch issues
- Reset `GLFW_MOUSE_PASSTHROUGH` on menu show to prevent stale passthrough state from previous sessions
- Re-establish `SetCapture` on each menu show

Fixes click-requires-two-taps issue in OneCommander and similar third-party file explorers.

## Root Cause

The context menu window is created with `WS_EX_NOACTIVATE` and uses GLFW for input. GLFW's event loop (`glfwWaitEvents`) runs in the `init_global` thread, but the menu window is created in the hooks thread. Windows delivers messages to the creating thread, so GLFW never processes the menu window's mouse messages — `glfwGetMouseButton()` returns stale state.

`GetAsyncKeyState(VK_LBUTTON)` queries hardware-level button state directly, independent of window messages, focus, or thread affinity.

## Test plan

- [ ] Right-click context menu in Windows Explorer — verify single click works
- [ ] Right-click context menu in OneCommander — verify single click works (previously required two clicks)
- [ ] Verify menu closes when clicking outside
- [ ] Verify submenu opening/closing works