### PR TITLE
fix: sentry-native build failure with clang-cl 22+

### DIFF
--- a/deps/sentry-native.lua
+++ b/deps/sentry-native.lua
@@ -95,6 +95,10 @@ package("sentry-native")
     end)
 
     on_install("windows|x86", "windows|x64", "linux", "macosx|x86_64", function (package) -- TODO: to enable android you will need to figure out the order of libs
+        -- Patch out -Werror to fix build with newer clang versions (22+)
+        local sourcedir = path.join(package:cachedir(), "source")
+        io.replace(path.join(sourcedir, "CMakeLists.txt"), "-Werror", "", {plain = true})
+
         local opt = {}
         local configs = {}
         table.insert(configs, "-DSENTRY_BUILD_EXAMPLES=OFF")


### PR DESCRIPTION
## Summary

- Patch out `-Werror` from sentry-native's CMakeLists.txt before cmake build

## Root Cause

clang-cl 22.1.4 introduces new warnings (`-Wc++-keyword`, `-Wimplicit-void-ptr-cast`, `-Wpadded`) that are promoted to errors by sentry-native 0.13.1's hardcoded `-Werror -Wall` in CMakeLists.txt. There is no cmake option to disable it.

## Test plan

- [ ] `xmake config --toolchain=clang-cl --mode=releasedbg --plat=windows` completes without sentry-native build errors
- [ ] `xmake b shell` builds successfully