### PR TITLE
fix: re-sync native menu item state after menu widget creation

### DIFF
--- a/src/shell/contextmenu/hooks.cc
+++ b/src/shell/contextmenu/hooks.cc
@@ -398,6 +398,37 @@ mb_shell::track_popup_menu(mb_shell::menu menu, int x, int y,
             menu_render.rt->last_time = menu_render.rt->clock.now();
             perf.end("menu_render::create");
 
+            // Re-sync native menu item states to catch async updates
+            // that arrived between construct_with_hmenu and now (e.g.,
+            // recycle bin "Empty Recycle Bin" enabled state).
+            if (auto root_menu = current_root_menu_widget()) {
+                HMENU hMenu = (HMENU)menu.native_handle;
+                int count = GetMenuItemCount(hMenu);
+                for (int i = 0; i < count; i++) {
+                    MENUITEMINFOW info{sizeof(MENUITEMINFOW)};
+                    info.fMask = MIIM_STATE;
+                    if (!GetMenuItemInfoW(hMenu, i, TRUE, &info))
+                        continue;
+                    auto identity =
+                        query_native_menu_item_identity(hMenu, i, TRUE);
+                    if (!identity)
+                        continue;
+                    auto target = find_menu_item_widget_by_identity(
+                        root_menu, *identity);
+                    if (!target)
+                        continue;
+                    bool disabled =
+                        (info.fState & (MFS_DISABLED | MFS_GRAYED)) != 0;
+                    if (target->item.disabled != disabled) {
+                        spdlog::info("Re-synced native menu item state: "
+                                     "item={}, disabled={} -> {}",
+                                     identity->name.value_or("?"),
+                                     target->item.disabled, disabled);
+                        target->item.disabled = disabled;
+                    }
+                }
+            }
+
             if (shift_pressed && menu_render.rt->nvg) {
                 spdlog::info("Resetting font atlas due to shift key pressed");
                 nvgFonsResetAtlas(menu_render.rt->nvg);


### PR DESCRIPTION
## Summary
- When right-clicking the Recycle Bin while it contains items, the "Empty Recycle Bin" menu item's enabled/disabled state was incorrect on the first open, requiring a second right-click to display correctly.
- Root cause: Windows asynchronously queries the recycle bin state after `WM_INITMENUPOPUP` and updates the native HMENU via `SetMenuItemInfoW`. This update arrives between `construct_with_hmenu` (which reads stale state) and the renderer thread setup (which enables the sync hooks), so it was silently dropped.
- Fix: Re-read native HMENU item states after `menu_render::create` to catch any async updates that arrived during this timing gap.

## Test plan
- [ ] Right-click the Recycle Bin when it contains items — "Empty Recycle Bin" should be enabled on the first open
- [ ] Right-click the Recycle Bin when it is empty — "Empty Recycle Bin" should be disabled
- [ ] Verify no regressions with normal file/folder context menus