### PR TITLE
fix: mini icons do not expand menu width

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
     "cmake.ignoreCMakeListsMissing": true,
     "files.associations": {
         "xstring": "cpp"
-    }
+    },
+    "C_Cpp.intelliSenseEngine": "disabled"
 }

--- a/src/shell/contextmenu/menu_widget.cc
+++ b/src/shell/contextmenu/menu_widget.cc
@@ -1058,6 +1058,17 @@ void mb_shell::menu_item_parent_widget::reset_appear_animation(float delay) {
     opacity->reset_to(0);
     opacity->animate_to(255);
 }
+float mb_shell::menu_item_parent_widget::measure_width(
+    ui::update_context &ctx) {
+    float total = 0;
+    float gap = config::current->context_menu.theme.multibutton_line_gap;
+    for (auto &child : children) {
+        total += child->measure_width(ctx);
+    }
+    if (!children.empty())
+        total += gap * (children.size() - 1);
+    return total;
+}
 void mb_shell::menu_item_normal_widget::hide_submenu() {
     if (submenu_wid != nullptr) {
         submenu_wid->close();

--- a/src/shell/contextmenu/menu_widget.h
+++ b/src/shell/contextmenu/menu_widget.h
@@ -39,6 +39,7 @@ struct menu_item_parent_widget : public menu_item_widget {
     using super = menu_item_widget;
     void update(ui::update_context &ctx) override;
     void reset_appear_animation(float delay) override;
+    float measure_width(ui::update_context &ctx) override;
 };
 
 struct menu_item_normal_widget : public menu_item_widget {


### PR DESCRIPTION
Before: 
<img width="479" height="139" alt="image" src="https://github.com/user-attachments/assets/981e81b8-39ea-47b6-99bd-784926014ad3" />
After:
<img width="697" height="178" alt="image" src="https://github.com/user-attachments/assets/ebd90159-1da1-4c8e-b8f7-f763047a96c0" />
