### PR TITLE
fix(shell): 修复 #367 - 使用 msyh.ttc 时部分菜单项显示 "□"

### DIFF
--- a/src/shell/config.cc
+++ b/src/shell/config.cc
@@ -1,4 +1,5 @@
 #include "config.h"
+#include <cctype>
 #include <chrono>
 #include <filesystem>
 #include <fstream>
@@ -156,10 +157,111 @@ std::filesystem::path config::default_mono_font() {
            "consola.ttf";
 }
 void config::apply_fonts_to_nvg(NVGcontext *nvg) {
-    ui::register_default_windows_font_suite(
-        nvg, {.main_regular = {.path = font_path_main},
-              .fallback_regular = {.path = font_path_fallback},
-              .monospace_regular = {.path = font_path_monospace}});
+    auto font_dir = ui::windows_font_directory();
+
+    auto to_lower = [](std::string s) {
+        for (auto &c : s)
+            c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+        return s;
+    };
+
+    auto add_with_system_variants =
+        [&](std::vector<ui::weighted_font_face> &faces,
+            const std::filesystem::path &user_path, const char *expected_name,
+            int collection_index = 0) {
+            if (user_path.empty())
+                return;
+            faces.push_back(
+                {.weight = 400,
+                 .source = {.path = user_path,
+                            .collection_index = collection_index}});
+
+            if (to_lower(user_path.filename().string()) !=
+                to_lower(expected_name))
+                return;
+
+            struct variant_entry {
+                int weight;
+                const char *file;
+            };
+            const variant_entry *variants = nullptr;
+            int variant_count = 0;
+
+            // clang-format off
+            if (to_lower(expected_name) == "segoeui.ttf") {
+                static constexpr variant_entry v[] = {
+                    {200, "segoeuisl.ttf"}, {300, "segoeuil.ttf"},
+                    {600, "seguisb.ttf"},   {700, "segoeuib.ttf"},
+                };
+                variants = v; variant_count = 4;
+            } else if (to_lower(expected_name) == "msyh.ttc") {
+                static constexpr variant_entry v[] = {
+                    {300, "msyhl.ttc"}, {700, "msyhbd.ttc"},
+                };
+                variants = v; variant_count = 2;
+            } else if (to_lower(expected_name) == "consola.ttf") {
+                static constexpr variant_entry v[] = {
+                    {700, "consolab.ttf"},
+                };
+                variants = v; variant_count = 1;
+            }
+            // clang-format on
+
+            for (int i = 0; i < variant_count; ++i) {
+                auto p = font_dir / variants[i].file;
+                if (std::filesystem::exists(p))
+                    faces.push_back(
+                        {.weight = variants[i].weight,
+                         .source = {.path = std::move(p),
+                                    .collection_index = collection_index}});
+            }
+        };
+
+    // 1. System Segoe UI – always available as ultimate fallback
+    {
+        std::vector<ui::weighted_font_face> faces;
+        add_with_system_variants(faces, font_dir / "segoeui.ttf",
+                                 "segoeui.ttf");
+        ui::register_font_family(nvg, {.family_name = "segoeui",
+                                       .faces = faces});
+    }
+
+    // 2. Fallback font (user-configured) – falls back to segoeui
+    //    For msyh.ttc use collection_index=1 → "Microsoft YaHei UI"
+    {
+        int fb_idx = 0;
+        if (to_lower(font_path_fallback.filename().string()) == "msyh.ttc")
+            fb_idx = 1;
+
+        std::vector<ui::weighted_font_face> faces;
+        add_with_system_variants(faces, font_path_fallback, "msyh.ttc",
+                                 fb_idx);
+        ui::register_font_family(
+            nvg, {.family_name = "fallback",
+                  .faces = faces,
+                  .fallback_families = {"segoeui"}});
+    }
+
+    // 3. Main font (user-configured) – falls back to segoeui + fallback
+    {
+        std::vector<ui::weighted_font_face> faces;
+        add_with_system_variants(faces, font_path_main, "segoeui.ttf");
+        ui::register_font_family(
+            nvg, {.family_name = "main",
+                  .faces = faces,
+                  .fallback_families = {"segoeui", "fallback"}});
+    }
+
+    // 4. Monospace font (user-configured) – falls back to main + segoeui +
+    // fallback
+    {
+        std::vector<ui::weighted_font_face> faces;
+        add_with_system_variants(faces, font_path_monospace, "consola.ttf");
+        ui::register_font_family(
+            nvg, {.family_name = "monospace",
+                  .faces = faces,
+                  .fallback_families = {"main", "segoeui", "fallback"}});
+    }
 }
 void config::animated_float_conf::apply_to(ui::animated_color &anim,
                                            float delay) {


### PR DESCRIPTION
## 复现

将 `font_path_main` 改为微软雅黑 `msyh.ttc` 后，回收站和图片文件的
右键菜单里部分选项会渲染成 `□`（fontstash 的 .notdef 字形）。
默认配置（`segoeui.ttf`）正常。

## 根因

`config::apply_fonts_to_nvg` 一直直接委托给
`ui::register_default_windows_font_suite`，其内部回退链写死成：
`main → fallback → system`。

这套设计基于一个隐含假设：用户配置的 main 是 Segoe UI（Latin），
fallback 是 msyh（中文）。换句话说——靠系统已经默认帮你把 Latin
和 CJK 拼好了。

但用户改了 `font_path_main = msyh.ttc` 之后，假设就破了：
- main = msyh.ttc
- fallback = msyh.ttc（用户没改这条，默认还是 msyh.ttc）
- system = Segoe UI

main 和 fallback 两个节点都是同一个 msyh.ttc，**没有任何拉丁/符号
字体兜底**。Shell 扩展菜单项的字符串里会夹带一些普通 CJK
之外的特殊 Unicode 字符（部分扩展程序用到的私有区符号、
半角连字、键盘上标之类的），这些字符在 msyh.ttc 里压根没有。
原来的设计里指望 Segoe UI 兜底，但现在 fallback 链里的
「system」压根不会被走到——因为「fallback」先于「system」，
且 fallback 自己就找不到、循环到下一个还是找不到就直接 break。

结果就是 `.notdef` → 一坨方框。

顺带还有个小问题：msyh.ttc 是个集合字体，index 0 是「Microsoft YaHei」
普通版，index 1 是「Microsoft YaHei UI」。之前的实现始终用 index 0，
但 UI 场景下用 YaHei UI 的字面度量和字形间距其实更合适。把它一起修了。

## 修复

不再委托给 `register_default_windows_font_suite`，直接在
`apply_fonts_to_nvg` 里手工注册四个字体族，固定把系统 Segoe UI
作为最终兜底：

| 字体族 | 来源 | fallback_families |
|---|---|---|
| `segoeui` | 系统 Segoe UI（硬加载，不依赖用户配置） | — |
| `fallback` | 用户配置（msyh.ttc 时 collection_index=1） | `{"segoeui"}` |
| `main` | 用户配置 | `{"segoeui", "fallback"}` |
| `monospace` | 用户配置 | `{"main", "segoeui", "fallback"}` |

不管用户怎么折腾 main 和 fallback，Segoe UI 始终在「main」的
fallback 链上一步，特殊符号字符总能找到字形。fallback 系列也
新增了 `segoeui` 兜底。

## 变更

- `src/shell/config.cc` 重写 `apply_fonts_to_nvg`
  - 新增 `segoeui` 字体族
  - 调整 `fallback` / `main` / `monospace` 的 `fallback_families`
  - msyh.ttc 自动选 collection_index=1（YaHei UI）
  - 字重变体通过 `add_with_system_variants` lambda 复用
- `src/shell/config.cc` 新增 `<cctype>` 头（文件名做大小写不敏感匹配）

close #367